### PR TITLE
Refactor: Rebuild planner pages with new UI theme

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -27,62 +27,81 @@ try {
     error_log("Dashboard Error: " . $e->getMessage());
 }
 
-
 require_once __DIR__ . '/includes/header-auth.php';
 require_once __DIR__ . '/includes/sidebar.php';
 ?>
 
-<!-- Page content starts here -->
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h4 class="card-title">Welcome, <?php echo htmlspecialchars($_SESSION['user_name']); ?>!</h4>
+<!--**********************************
+    Content body start
+***********************************-->
+<div class="content-body rightside-event">
+    <!-- row -->
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-xl-12">
+                <div class="welcome-card rounded ps-5 pt-5 pb-4 mt-3 position-relative mb-5">
+                    <h4 class="text-warning">Welcome, <?php echo htmlspecialchars($_SESSION['user_name']); ?>!</h4>
+                    <p>Here is a summary of your events and sales.</p>
+                    <a class="btn btn-warning btn-rounded" href="my-events.php">View My Events</a>
+                    <a class="btn-link text-dark ms-3" href="create-event.php">Create New Event</a>
+                    <img src="images/svg/welcom-card.svg" alt="" class="position-absolute">
+                </div>
             </div>
-            <div class="card-body">
-                <?php if (isset($page_error)): ?>
+
+            <?php if (isset($page_error)): ?>
+                <div class="col-xl-12">
                     <div class="alert alert-danger"><?php echo $page_error; ?></div>
-                <?php endif; ?>
+                </div>
+            <?php endif; ?>
 
-                <?php if ($user_role === 'planner'): ?>
-                    <div class="d-flex justify-content-between align-items-center mb-3">
-                        <h5 class="card-title">My Events</h5>
-                        <div>
-                            <a href="create-event.php" class="btn btn-primary">Create New Event</a>
-                            <a href="manage-team.php" class="btn btn-info" style="margin-left: 10px;">Manage Team</a>
-                        </div>
-                    </div>
-                    <?php if (!empty($planner_events)): ?>
-                        <div class="table-responsive">
-                            <table class="table table-striped">
-                                <thead>
-                                    <tr>
-                                        <th>Title</th>
-                                        <th>Date</th>
-                                        <th>Status</th>
-                                        <th>Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <?php foreach ($planner_events as $event): ?>
-                                        <tr>
-                                            <td><?php echo htmlspecialchars($event->title); ?></td>
-                                            <td><?php echo date('F j, Y, g:i a', strtotime($event->date)); ?></td>
-                                            <td><span class="badge light badge-primary"><?php echo htmlspecialchars($event->status); ?></span></td>
-                                            <td>
-                                                <a href="edit-event.php?id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-sm btn-secondary">Manage</a>
-                                                <a href="scan-ticket.php?event_id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-sm btn-success">Scan Tickets</a>
-                                            </td>
-                                        </tr>
-                                    <?php endforeach; ?>
-                                </tbody>
-                            </table>
-                        </div>
-                    <?php else: ?>
-                        <p>You have not created any events yet.</p>
-                    <?php endif; ?>
+            <?php if ($user_role === 'planner'): ?>
+                <div class="col-xl-12">
+						<div id="user-activity" class="card">
+							<div class="card-header border-0 pb-0 d-sm-flex d-block">
+								<div>
+									<h4 class="card-title mb-1">My Events</h4>
+								</div>
+								<div class="card-action card-tabs mt-3 mt-sm-0">
+                                    <a href="create-event.php" class="btn btn-primary">Create New Event</a>
+                                    <a href="manage-team.php" class="btn btn-info" style="margin-left: 10px;">Manage Team</a>
+								</div>
+							</div>
+							<div class="card-body">
+                                <?php if (!empty($planner_events)): ?>
+                                    <div class="table-responsive">
+                                        <table class="table table-striped">
+                                            <thead>
+                                                <tr>
+                                                    <th>Title</th>
+                                                    <th>Date</th>
+                                                    <th>Status</th>
+                                                    <th>Actions</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <?php foreach ($planner_events as $event): ?>
+                                                    <tr>
+                                                        <td><?php echo htmlspecialchars($event->title); ?></td>
+                                                        <td><?php echo date('F j, Y, g:i a', strtotime($event->date)); ?></td>
+                                                        <td><span class="badge light badge-primary"><?php echo htmlspecialchars($event->status); ?></span></td>
+                                                        <td>
+                                                            <a href="edit-event.php?id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-sm btn-secondary">Manage</a>
+                                                            <a href="scan-ticket.php?event_id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-sm btn-success">Scan Tickets</a>
+                                                        </td>
+                                                    </tr>
+                                                <?php endforeach; ?>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                <?php else: ?>
+                                    <p>You have not created any events yet.</p>
+                                <?php endif; ?>
+							</div>
+						</div>
+					</div>
 
-                <?php elseif ($user_role === 'attendee'): ?>
+            <?php elseif ($user_role === 'attendee'): ?>
+                <div class="col-xl-12">
                     <h5 class="card-title">My Tickets</h5>
                     <?php if (!empty($attendee_tickets)): ?>
                         <div class="table-responsive">
@@ -110,12 +129,14 @@ require_once __DIR__ . '/includes/sidebar.php';
                     <?php else: ?>
                         <p>You have not purchased any tickets yet.</p>
                     <?php endif; ?>
-                <?php endif; ?>
-            </div>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 </div>
-<!-- Page content ends here -->
+<!--**********************************
+    Content body end
+***********************************-->
 
 <?php
 require_once __DIR__ . '/includes/footer-auth.php';

--- a/edit-event.php
+++ b/edit-event.php
@@ -42,97 +42,154 @@ require_once __DIR__ . '/includes/header-auth.php';
 require_once __DIR__ . '/includes/sidebar.php';
 ?>
 
-<div class="row">
-    <!-- Event Details Column -->
-    <div class="col-xl-7">
-        <div class="card">
-            <div class="card-header">
-                <h4 class="card-title">Manage Event: <?php echo htmlspecialchars($event->title); ?></h4>
-            </div>
-            <div class="card-body">
-                <!-- In a future step, we can make this form editable -->
-                <p><strong>Status:</strong> <span class="badge light badge-primary"><?php echo htmlspecialchars($event->status); ?></span></p>
-                <p><strong>Date:</strong> <?php echo date('F j, Y, g:i a', strtotime($event->date)); ?></p>
-                <p><strong>Location:</strong> <?php echo htmlspecialchars($event->location); ?></p>
-                <p><strong>Description:</strong> <?php echo nl2br(htmlspecialchars($event->description)); ?></p>
-                <?php if ($event->banner): ?>
-                    <p><strong>Banner:</strong></p>
-                    <img src="<?php echo htmlspecialchars($event->banner); ?>" alt="Event Banner" class="img-fluid rounded">
-                <?php endif; ?>
-            </div>
+<!--**********************************
+    Content body start
+***********************************-->
+<div class="content-body">
+    <!-- row -->
+    <div class="container-fluid">
+        <div class="page-titles">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="dashboard.php">Dashboard</a></li>
+                <li class="breadcrumb-item active"><a href="javascript:void(0)"><?php echo htmlspecialchars($event->title); ?></a></li>
+            </ol>
         </div>
-
-        <div class="card">
-            <div class="card-header">
-                <h4 class="card-title">Existing Ticket Types</h4>
-            </div>
-            <div class="card-body">
-                <div class="table-responsive">
-                    <?php if (!empty($tickets)): ?>
-                        <table class="table table-striped">
-                            <thead>
-                                <tr>
-                                    <th>Ticket Name</th>
-                                    <th>Price</th>
-                                    <th>Quantity</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <?php foreach ($tickets as $ticket): ?>
-                                    <tr>
-                                        <td><?php echo htmlspecialchars($ticket->name); ?></td>
-                                        <td>$<?php echo htmlspecialchars(number_format($ticket->price, 2)); ?></td>
-                                        <td><?php echo htmlspecialchars($ticket->quantity); ?></td>
-                                    </tr>
-                                <?php endforeach; ?>
-                            </tbody>
-                        </table>
-                    <?php else: ?>
-                        <p>No ticket types have been added for this event yet.</p>
-                    <?php endif; ?>
+        <div class="row">
+            <div class="col-xl-9 col-xxl-8">
+                <div class="row">
+                    <div class="col-xl-12">
+                        <div class="card event-bx overflow-hidden">
+                            <div class="card-media">
+                                <img src="<?php echo htmlspecialchars($event->banner); ?>" alt="">
+                            </div>
+                            <div class="card-body">
+                                <div class="row align-items-center">
+                                    <div class="col-xl-8 col-xxl-8">
+                                        <div class="border-xl-end pe-xl-4 pe-lg-2">
+                                            <h4 class="text-black">Event Description</h4>
+                                            <p><?php echo nl2br(htmlspecialchars($event->description)); ?></p>
+                                        </div>
+                                    </div>
+                                    <div class="col-xl-4 col-xxl-4">
+                                        <div class="media mb-3 align-items-center">
+                                            <div class="me-3">
+                                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <g clip-path="">
+                                                    <path d="M21 3H20C20 2.20435 19.6839 1.44129 19.1213 0.87868C18.5587 0.31607 17.7956 0 17 0C16.2044 0 15.4413 0.31607 14.8787 0.87868C14.3161 1.44129 14 2.20435 14 3H10C10 2.20435 9.68393 1.44129 9.12132 0.87868C8.55871 0.316071 7.79565 4.47035e-08 7 4.47035e-08C6.20435 4.47035e-08 5.44129 0.316071 4.87868 0.87868C4.31607 1.44129 4 2.20435 4 3H3C2.20435 3 1.44129 3.31607 0.87868 3.87868C0.31607 4.44129 0 5.20435 0 6L0 21C0 21.7956 0.31607 22.5587 0.87868 23.1213C1.44129 23.6839 2.20435 24 3 24H21C21.7956 24 22.5587 23.6839 23.1213 23.1213C23.6839 22.5587 24 21.7956 24 21V6C24 5.20435 23.6839 4.44129 23.1213 3.87868C22.5587 3.31607 21.7956 3 21 3ZM3 5H4C4 5.79565 4.31607 6.55871 4.87868 7.12132C5.44129 7.68393 6.20435 8 7 8C7.26522 8 7.51957 7.89464 7.70711 7.70711C7.89464 7.51957 8 7.26522 8 7C8 6.73478 7.89464 6.48043 7.70711 6.29289C7.51957 6.10536 7.26522 6 7 6C6.73478 6 6.48043 5.89464 6.29289 5.70711C6.10536 5.51957 6 5.26522 6 5V3C6 2.73478 6.10536 2.48043 6.29289 2.29289C6.48043 2.10536 6.73478 2 7 2C7.26522 2 7.51957 2.10536 7.70711 2.29289C7.89464 2.48043 8 2.73478 8 3V4C8 4.26522 8.10536 4.51957 8.29289 4.70711C8.48043 4.89464 8.73478 5 9 5H14C14 5.79565 14.3161 6.55871 14.8787 7.12132C15.4413 7.68393 16.2044 8 17 8C17.2652 8 17.5196 7.89464 17.7071 7.70711C17.8946 7.51957 18 7.26522 18 7C18 6.73478 17.8946 6.48043 17.7071 6.29289C17.5196 6.10536 17.2652 6 17 6C16.7348 6 16.4804 5.89464 16.2929 5.70711C16.1054 5.51957 16 5.26522 16 5V3C16 2.73478 16.1054 2.48043 16.2929 2.29289C16.4804 2.10536 16.7348 2 17 2C17.2652 2 17.5196 2.10536 17.7071 2.29289C17.8946 2.48043 18 2.73478 18 3V4C18 4.26522 18.1054 4.51957 18.2929 4.70711C18.4804 4.89464 18.7348 5 19 5H21C21.2652 5 21.5196 5.10536 21.7071 5.29289C21.8946 5.48043 22 5.73478 22 6V10H2V6C2 5.73478 2.10536 5.48043 2.29289 5.29289C2.48043 5.10536 2.73478 5 3 5ZM21 22H3C2.73478 22 2.48043 21.8946 2.29289 21.7071C2.10536 21.5196 2 21.2652 2 21V12H22V21C22 21.2652 21.8946 21.5196 21.7071 21.7071C21.5196 21.8946 21.2652 22 21 22Z" fill="var(--primary)"></path>
+                                                    <path d="M12 16C12.5523 16 13 15.5523 13 15C13 14.4477 12.5523 14 12 14C11.4477 14 11 14.4477 11 15C11 15.5523 11.4477 16 12 16Z" fill="var(--primary)"></path>
+                                                    <path d="M18 16C18.5523 16 19 15.5523 19 15C19 14.4477 18.5523 14 18 14C17.4477 14 17 14.4477 17 15C17 15.5523 17.4477 16 18 16Z" fill="var(--primary)"></path>
+                                                    <path d="M6 16C6.55228 16 7 15.5523 7 15C7 14.4477 6.55228 14 6 14C5.44771 14 5 14.4477 5 15C5 15.5523 5.44771 16 6 16Z" fill="var(--primary)"></path>
+                                                    <path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" fill="var(--primary)"></path>
+                                                    <path d="M18 20C18.5523 20 19 19.5523 19 19C19 18.4477 18.5523 18 18 18C17.4477 18 17 18.4477 17 19C17 19.5523 17.4477 20 18 20Z" fill="var(--primary)"></path>
+                                                    <path d="M6 20C6.55228 20 7 19.5523 7 19C7 18.4477 6.55228 18 6 18C5.44771 18 5 18.4477 5 19C5 19.5523 5.44771 20 6 20Z" fill="var(--primary)"></path>
+                                                    </g>
+                                                </svg>
+                                            </div>
+                                            <div class="media-body">
+                                                <p class="mb-0">Date</p>
+                                                <h5 class="mb-0 text-black"><?php echo date('F j, Y, g:i a', strtotime($event->date)); ?></h5>
+                                            </div>
+                                        </div>
+                                        <div class="media mb-3 align-items-center">
+                                            <div class="me-3">
+                                                <svg width="24" height="24" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                    <g clip-path="">
+                                                    <path d="M27.5711 13.4286C27.5711 22.4286 15.9997 30.1428 15.9997 30.1428C15.9997 30.1428 4.42822 22.4286 4.42822 13.4286C4.42822 10.3596 5.64735 7.41638 7.81742 5.24632C9.98748 3.07625 12.9307 1.85712 15.9997 1.85712C19.0686 1.85712 22.0118 3.07625 24.1819 5.24632C26.3519 7.41638 27.5711 10.3596 27.5711 13.4286Z" stroke="var(--primary)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                    <path d="M15.9997 17.2857C18.13 17.2857 19.8569 15.5588 19.8569 13.4286C19.8569 11.2983 18.13 9.57141 15.9997 9.57141C13.8695 9.57141 12.1426 11.2983 12.1426 13.4286C12.1426 15.5588 13.8695 17.2857 15.9997 17.2857Z" stroke="var(--primary)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+                                                    </g>
+                                                </svg>
+                                            </div>
+                                            <div class="media-body">
+                                                <p class="mb-0">Location</p>
+                                                <h5 class="mb-0 text-black"><?php echo htmlspecialchars($event->location); ?></h5>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
+            <div class="col-xl-3 col-xxl-4">
+						<div class="row">
+							<div class="col-md-12">
+								<div class="card">
+									<div class="card-header">
+                                        <h4 class="card-title">Add New Ticket Type</h4>
+                                    </div>
+                                    <div class="card-body">
+                                        <div id="add-ticket-error" class="alert alert-danger" style="display: none;"></div>
+                                        <div id="add-ticket-success" class="alert alert-success" style="display: none;"></div>
 
-    <!-- Add Ticket Column -->
-    <div class="col-xl-5">
-        <div class="card">
-            <div class="card-header">
-                <h4 class="card-title">Add New Ticket Type</h4>
-            </div>
-            <div class="card-body">
-                <div id="add-ticket-error" class="alert alert-danger" style="display: none;"></div>
-                <div id="add-ticket-success" class="alert alert-success" style="display: none;"></div>
+                                        <form id="add-ticket-form" method="POST">
+                                            <input type="hidden" name="csrf_token" value="<?php echo CSRF::generateToken('add_ticket_form'); ?>">
+                                            <input type="hidden" name="event_id" value="<?php echo $event->id; ?>">
 
-                <form id="add-ticket-form" method="POST">
-                    <input type="hidden" name="csrf_token" value="<?php echo CSRF::generateToken('add_ticket_form'); ?>">
-                    <input type="hidden" name="event_id" value="<?php echo $event->id; ?>">
-
-                    <div class="mb-3">
-                        <label class="form-label">Ticket Name (e.g., General Admission, VIP)</label>
-                        <input type="text" class="form-control" name="name" required>
-                        <div class="invalid-feedback"></div>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Price ($)</label>
-                        <input type="number" class="form-control" name="price" min="0" step="0.01" required>
-                        <div class="invalid-feedback"></div>
-                    </div>
-                    <div class="mb-3">
-                        <label class="form-label">Quantity Available</label>
-                        <input type="number" class="form-control" name="quantity" min="1" required>
-                        <div class="invalid-feedback"></div>
-                    </div>
-                    <button type="submit" id="add-ticket-button" class="btn btn-primary">
-                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none;"></span>
-                        Add Ticket
-                    </button>
-                </form>
-            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Ticket Name (e.g., General Admission, VIP)</label>
+                                                <input type="text" class="form-control" name="name" required>
+                                                <div class="invalid-feedback"></div>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Price ($)</label>
+                                                <input type="number" class="form-control" name="price" min="0" step="0.01" required>
+                                                <div class="invalid-feedback"></div>
+                                            </div>
+                                            <div class="mb-3">
+                                                <label class="form-label">Quantity Available</label>
+                                                <input type="number" class="form-control" name="quantity" min="1" required>
+                                                <div class="invalid-feedback"></div>
+                                            </div>
+                                            <button type="submit" id="add-ticket-button" class="btn btn-primary">
+                                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none;"></span>
+                                                Add Ticket
+                                            </button>
+                                        </form>
+                                    </div>
+								</div>
+							</div>
+                            <div class="col-md-12">
+                                <div class="card">
+                                    <div class="card-header">
+                                        <h4 class="card-title">Existing Ticket Types</h4>
+                                    </div>
+                                    <div class="card-body">
+                                        <div class="table-responsive">
+                                            <?php if (!empty($tickets)): ?>
+                                                <table class="table table-striped">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Ticket Name</th>
+                                                            <th>Price</th>
+                                                            <th>Quantity</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <?php foreach ($tickets as $ticket): ?>
+                                                            <tr>
+                                                                <td><?php echo htmlspecialchars($ticket->name); ?></td>
+                                                                <td>$<?php echo htmlspecialchars(number_format($ticket->price, 2)); ?></td>
+                                                                <td><?php echo htmlspecialchars($ticket->quantity); ?></td>
+                                                            </tr>
+                                                        <?php endforeach; ?>
+                                                    </tbody>
+                                                </table>
+                                            <?php else: ?>
+                                                <p>No ticket types have been added for this event yet.</p>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+						</div>
+					</div>
         </div>
     </div>
 </div>
+<!--**********************************
+    Content body end
+***********************************-->
 
 <script src="assets/js/event.js"></script>
 

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -9,6 +9,11 @@
                     <span class="nav-text">Dashboard</span>
                 </a>
             </li>
+            <li><a href="my-events.php" class="ai-icon" aria-expanded="false">
+                    <i class="flaticon-381-list-1"></i>
+                    <span class="nav-text">My Events</span>
+                </a>
+            </li>
             <li><a href="create-event.php" class="ai-icon" aria-expanded="false">
                     <i class="flaticon-381-add-1"></i>
                     <span class="nav-text">Create Event</span>
@@ -23,16 +28,6 @@
                     <i class="flaticon-381-search-1"></i>
                     <span class="nav-text">Scan Ticket</span>
                 </a>
-            </li>
-            <!-- Placeholder for other links -->
-            <li><a class="has-arrow ai-icon" href="javascript:void(0);" aria-expanded="false">
-                    <i class="flaticon-381-layer-1"></i>
-                    <span class="nav-text">Pages</span>
-                </a>
-                <ul aria-expanded="false">
-                    <li><a href="page-register.html">Register</a></li>
-                    <li><a href="page-login.html">Login</a></li>
-                </ul>
             </li>
         </ul>
         <div class="copyright">

--- a/my-events.php
+++ b/my-events.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/repositories/EventRepository.php';
+require_once __DIR__ . '/utils/URLUtils.php';
+
+// AuthGuard is included in header-auth.php
+$user_role = $_SESSION['user_role'];
+$user_id = $_SESSION['user_id'];
+
+if ($user_role !== 'planner') {
+    // Only planners can access this page
+    header("Location: dashboard.php");
+    exit;
+}
+
+$page_title = "My Events";
+
+$eventRepo = new EventRepository($pdo);
+$planner_events = $eventRepo->findEventsByPlanner($user_id);
+
+require_once __DIR__ . '/includes/header-auth.php';
+require_once __DIR__ . '/includes/sidebar.php';
+?>
+
+<!--**********************************
+    Content body start
+***********************************-->
+<div class="content-body">
+    <!-- row -->
+    <div class="container-fluid">
+        <div class="row page-titles">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="dashboard.php">Dashboard</a></li>
+                <li class="breadcrumb-item active"><a href="javascript:void(0)">My Events</a></li>
+            </ol>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h4 class="card-title">All My Events</h4>
+                        <a href="create-event.php" class="btn btn-primary">Create New Event</a>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive ticket-table">
+                            <table id="example" class="display dataTablesCard table-responsive-xl" style="min-width: 845px">
+                                <thead>
+                                    <tr>
+                                        <th>Title</th>
+                                        <th>Date</th>
+                                        <th>Status</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($planner_events as $event): ?>
+                                        <tr>
+                                            <td><?php echo htmlspecialchars($event->title); ?></td>
+                                            <td><?php echo date('F j, Y, g:i a', strtotime($event->date)); ?></td>
+                                            <td><span class="badge light badge-primary"><?php echo htmlspecialchars($event->status); ?></span></td>
+                                            <td>
+                                                <div class="d-flex">
+                                                    <a href="edit-event.php?id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-primary shadow btn-xs sharp me-1"><i class="fas fa-pencil-alt"></i></a>
+                                                    <a href="scan-ticket.php?event_id=<?php echo URLUtils::encrypt($event->id); ?>" class="btn btn-success shadow btn-xs sharp"><i class="fas fa-camera"></i></a>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<!--**********************************
+    Content body end
+***********************************-->
+
+<?php
+require_once __DIR__ . '/includes/footer-auth.php';
+?>


### PR DESCRIPTION
This commit redesigns the planner-facing pages to provide a richer and more modern user experience, as outlined below:

- Planner Dashboard (`dashboard.php`): Rebuilt using the `UI theme/index.html` template. This provides planners with a more comprehensive overview of their stats and events.

- Planner's "Manage Event" Page (`edit-event.php`): Rebuilt using the `UI theme/events.html` template. This page now serves as a detailed dashboard for a single event, accessible only to the event owner.

- Planner's "Event List" Page (`my-events.php`): This is a new page created from the `UI theme/all-ticket.html` template. It features a powerful DataTable for planners to view, sort, and manage all their created events.

- Sidebar Navigation (`includes/sidebar.php`): Updated to include a link to the new "My Events" page for easy access.

The public-facing pages (`event.php` and `index.php`) remain unchanged.